### PR TITLE
Prepare library for Shelly unicast support

### DIFF
--- a/lib/coap/index.js
+++ b/lib/coap/index.js
@@ -60,18 +60,17 @@ const requestStatusUpdates = (statusUpdateHandler, timeout = 500) => {
 
 const listenForStatusUpdates = (statusUpdateHandler, networkInterface) => {
   const server = coap.createServer({
-    multicastAddress: COAP_MULTICAST_ADDRESS,
-    multicastInterface: networkInterface,
+    multicastAddress: COAP_MULTICAST_ADDRESS
   })
 
   server.on('request', req => {
-    if (req.code === '0.30' && req.url === '/cit/s' && statusUpdateHandler) {
+    if ((req.code === '0.30' || req.code === '2.05') && req.url === '/cit/s' && statusUpdateHandler) {
       statusUpdateHandler.call(server, new CoapMessage(req))
     }
   })
 
   return new Promise((resolve, reject) => {
-    server.listen(err => {
+    server.listen(5683, err => {
       if (err) {
         reject(err, server)
       } else {


### PR DESCRIPTION
This PR updates the node-shellies library to support unicast for Shelly devices. Unfortunately the node-coap library contains code which prevents this from working correctly. Unicast Shelly devices send requests with the 2.05 content request code which get dropped here:  https://github.com/mcollina/node-coap/blob/7a4b770f7fd92f389b7bde3d1c57b6d1822882b0/lib/server.js#L300

Updating this line to `if (packet.code[0] !== '0' && packet.code !== '2.05') {` and using this changes in this PR will ensure that unicast is supported.