### PR TITLE
Support CoAP unicast messages

### DIFF
--- a/lib/coap/index.js
+++ b/lib/coap/index.js
@@ -64,6 +64,21 @@ const listenForStatusUpdates = (statusUpdateHandler, networkInterface) => {
     multicastInterface: networkInterface,
   })
 
+  // insert our own middleware right before requests are handled (the last step)
+  server._middlewares.splice(
+    Math.max(server._middlewares.length - 1, 0),
+    0,
+    (req, next) => {
+      // Unicast messages from Shelly devices will have the 2.05 code, which the
+      // server will silently drop (since its a response code and not a request
+      // code). To avoid this, we change it to 0.30 here.
+      if (req.packet.code === '2.05') {
+        req.packet.code = '0.30'
+      }
+      next()
+    }
+  )
+
   server.on('request', req => {
     if (req.code === '0.30' && req.url === '/cit/s' && statusUpdateHandler) {
       statusUpdateHandler.call(server, new CoapMessage(req))


### PR DESCRIPTION
This will change the message code for Shelly unicast messages from 2.05 to 0.30 right before they are handled by the server, to work around the fact that the node-coap server will drop any requests with codes that don't start with a 0.

@jghaanstra Can you see if this works for you?